### PR TITLE
Use proper syntax for including helpers

### DIFF
--- a/app/mailers/nopassword/no_password_emails.rb
+++ b/app/mailers/nopassword/no_password_emails.rb
@@ -1,6 +1,6 @@
 module Nopassword
   class NoPasswordEmails < ActionMailer::Base
-    include ApplicationHelper
+    include Nopassword::ApplicationHelper
 
     default :from => 'nopassword@alexsmolen.com',
       :return_path => 'nopassword@alexsmolen.com'


### PR DESCRIPTION
Hi Alex.  Thanks for putting this together.

I added this to a Rails 3.2.8 app and got an undefined method error trying to login from a helper method the mailer was causing.  On a hunch, I added the namespace to the constant invocation and that seemed to fix it.  Not sure if this is a real bug or I just set this up wrong, but everything worked beautifully after that so I'm opening this in case you want to merge it in.
