### PR TITLE
Use 'root_url' when redirecting

### DIFF
--- a/app/controllers/nopassword/check_session.rb
+++ b/app/controllers/nopassword/check_session.rb
@@ -5,7 +5,7 @@ module Nopassword
         @current_session = Nopassword::LoginSession.find_by_id(session[:login_session])
         if !@current_session.active?
           session[:login_session] = nil
-          redirect_to '/'
+          redirect_to root_url
         end
       end
     end

--- a/app/controllers/nopassword/nopassword_controller.rb
+++ b/app/controllers/nopassword/nopassword_controller.rb
@@ -7,7 +7,7 @@ module Nopassword
     before_filter :check_valid_session
 
     def send_login_email
-      redirect_to '/' if !request.post?
+      redirect_to root_url if !request.post?
       email = request[:email]
       remote_ip = request.remote_ip
       user_agent = request.env["HTTP_USER_AGENT"]
@@ -18,7 +18,7 @@ module Nopassword
       else
         flash[:notice] = "That doesn't look like a valid email address."
       end
-      redirect_to '/'
+      redirect_to root_url
     end
 
     def login
@@ -38,13 +38,13 @@ module Nopassword
       else
         session[:login_session] = login_session.id
       end
-      redirect_to '/'
+      redirect_to root_url
     end
 
     def logout
       @current_session.logout
       session[:login_session] = nil
-      redirect_to '/'
+      redirect_to root_url
     end
 
     def revoke


### PR DESCRIPTION
When redirecting back to the root, use 'root_url' instead of a hard-coded '/'. The slash does not work as expected when the app isn't running on the root.
For example, if the app is on http://example.com/app/, using `redirect_to '/'` redirects to http://example.com/. Using `redirect_to root_url` redirects to http://example.com/app, which is what you'd expect.
