### PR TITLE
Use config setting for from emails

### DIFF
--- a/app/mailers/nopassword/no_password_emails.rb
+++ b/app/mailers/nopassword/no_password_emails.rb
@@ -2,8 +2,8 @@ module Nopassword
   class NoPasswordEmails < ActionMailer::Base
     include ApplicationHelper
 
-    default :from => 'nopassword@alexsmolen.com',
-      :return_path => 'nopassword@alexsmolen.com'
+    default :from => Nopassword::Engine.config.from_email,
+      :return_path => Nopassword::Engine.config.return_email
 
     def no_password_email(email, id, time, remote_ip, user_agent, geo, code, host)
       @id = id

--- a/lib/nopassword/engine.rb
+++ b/lib/nopassword/engine.rb
@@ -35,5 +35,8 @@ module Nopassword
         :authentication       => 'plain',
         :enable_starttls_auto => true  }
     end
+
+    config.from_email = 'nopassword@alexsmolen.com'
+    config.return_email = 'nopassword@alexsmolen.com'
   end
 end


### PR DESCRIPTION
This makes it possible to change the from email settings in nopassword by setting a config param in the parent app's initializer.
